### PR TITLE
Add DOMPurify sanitization for Markdown rendering

### DIFF
--- a/scripts/timeline.js
+++ b/scripts/timeline.js
@@ -285,9 +285,9 @@ sections.forEach(sec=>{
     block.appendChild(img);
   }
   const cap=document.createElement("div"); cap.className="section-caption";
-  cap.innerHTML = renderMarkdown((sec.cap || "").trim()); block.appendChild(cap);
+  cap.innerHTML = DOMPurify.sanitize(renderMarkdown((sec.cap || "").trim())); block.appendChild(cap);
   const desc=document.createElement("div"); desc.className="section-description";
-  desc.innerHTML = renderMarkdown((sec.desc || "").trim()); block.appendChild(desc);
+  desc.innerHTML = DOMPurify.sanitize(renderMarkdown((sec.desc || "").trim())); block.appendChild(desc);
 
   wrapper.appendChild(block);
 
@@ -333,10 +333,10 @@ sections.forEach(sec=>{
         card.appendChild(im);
       }
       const c = document.createElement("div"); c.className="entry-caption";
-      c.innerHTML = renderMarkdown((e.cap||"").trim()); card.appendChild(c);
+      c.innerHTML = DOMPurify.sanitize(renderMarkdown((e.cap||"").trim())); card.appendChild(c);
 
       const d = document.createElement("div"); d.className="entry-description";
-      d.innerHTML = renderMarkdown((e.desc||"").trim());
+      d.innerHTML = DOMPurify.sanitize(renderMarkdown((e.desc||"").trim()));
       card.appendChild(d);
 
       wrap.appendChild(card);

--- a/timeline.html
+++ b/timeline.html
@@ -72,6 +72,7 @@
   </div>
 </footer>
 
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
 <script src="scripts/timeline.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
## Summary
- Load DOMPurify in `timeline.html`
- Sanitize rendered Markdown before assigning to `innerHTML`

## Testing
- `node --check scripts/timeline.js`
- `npx --yes --package=jsdom --package=dompurify node - <<'NODE' ... NODE` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adf889a25c8321b6cdacb25e6861cd