### PR TITLE
Add CSV parser tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+## Running tests
+
+This project uses the Node.js built-in test runner.
+To execute the test suite, run:
+
+```bash
+npm test
+```
+
+or directly:
+
+```bash
+node --test
+```
+
+The tests live in the `tests/` directory and cover CSV parsing edge cases.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "timeline-from-google-sheet",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/scripts/parseCSV.js
+++ b/scripts/parseCSV.js
@@ -1,0 +1,21 @@
+function parseCSV(text){
+  const rows=[]; let field="", row=[], inQ=false;
+  for(let i=0;i<text.length;i++){
+    const c=text[i];
+    if(inQ){
+      if(c==='"'){ if(text[i+1]==='"'){ field+='"'; i++; } else inQ=false; }
+      else field+=c;
+    } else {
+      if(c==='"') inQ=true;
+      else if(c===','){ row.push(field); field=""; }
+      else if(c==='\n'){ row.push(field); rows.push(row); row=[]; field=""; }
+      else if(c!=='\r'){ field+=c; }
+    }
+  }
+  row.push(field);
+  if(row.length>1 || row[0]!=="") rows.push(row);
+  return rows;
+}
+
+if (typeof module !== 'undefined') module.exports = parseCSV;
+if (typeof window !== 'undefined') window.parseCSV = parseCSV;

--- a/scripts/timeline.js
+++ b/scripts/timeline.js
@@ -50,24 +50,7 @@ window.addEventListener("keydown", e=>{ if(e.key==="Escape") closeMenu(); });
 setMenuTabIndices(true);
 
 /* ===== CSV ===== */
-function parseCSV(text){
-const rows=[]; let field="", row=[], inQ=false;
-for(let i=0;i<text.length;i++){
-  const c=text[i];
-  if(inQ){
-    if(c==='"'){ if(text[i+1]==='"'){ field+='"'; i++; } else inQ=false; }
-    else field+=c;
-  } else {
-    if(c==='"') inQ=true;
-    else if(c===','){ row.push(field); field=""; }
-    else if(c==='\n'){ row.push(field); rows.push(row); row=[]; field=""; }
-    else if(c!=='\r'){ field+=c; }
-  }
-}
-row.push(field);
-if(row.length>1 || row[0]!=="") rows.push(row);
-return rows;
-}
+/* parseCSV is defined in parseCSV.js */
 function kvFromTwoColumn(rows){
 const kv={};
 for(const r of rows){ const k=(r[0]||"").trim(); const v=(r[1]||"").trim(); if(k) kv[k]=v; }

--- a/tests/parseCSV.test.js
+++ b/tests/parseCSV.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const parseCSV = require('../scripts/parseCSV');
+
+test('handles quoted fields', () => {
+  const csv = '"a","b","c"';
+  assert.deepStrictEqual(parseCSV(csv), [["a","b","c"]]);
+});
+
+test('handles escaped quotes', () => {
+  const csv = '"a","b ""c"" d","e"';
+  assert.deepStrictEqual(parseCSV(csv), [["a","b \"c\" d","e"]]);
+});
+
+test('handles empty rows', () => {
+  const csv = 'a,b\n\nc,d';
+  assert.deepStrictEqual(parseCSV(csv), [["a","b"],[""],["c","d"]]);
+});
+
+test('parses multiline fields', () => {
+  const csv = 'a,"b\nc",d';
+  assert.deepStrictEqual(parseCSV(csv), [["a","b\nc","d"]]);
+});

--- a/timeline.html
+++ b/timeline.html
@@ -73,6 +73,7 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
+<script src="scripts/parseCSV.js"></script>
 <script src="scripts/timeline.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
## Summary
- Extract CSV parsing logic into standalone `parseCSV` module usable in both browser and Node
- Load the new parser module in the HTML and document its availability in `timeline.js`
- Add Node test runner, comprehensive parser tests, and contributing guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfa4b1cd4832197850776820cf65f