### PR TITLE
feat: sync individual rows from Source to Export

### DIFF
--- a/apps-script/export.gs
+++ b/apps-script/export.gs
@@ -1,0 +1,89 @@
+/** Timeline Export — auto-sync, preserves rich text formatting */
+const SOURCE_SHEET = 'Source';
+const EXPORT_SHEET = 'Export';
+const HEADER = ['Type', 'Value'];
+
+function initializeExport() {
+  const { exp } = ensureSheets();
+  exp.clear();
+  exp.getRange(1, 1, 1, 2).setValues([HEADER]);
+  syncExport({ silent: false });
+}
+
+function onEdit(e) {
+  try {
+    if (!e || !e.range) return;
+    const sh = e.range.getSheet();
+    if (!sh || sh.getName() !== SOURCE_SHEET) return;
+    if (e.range.getColumn() > 2) return;
+    Utilities.sleep(150);
+    syncExport({ row: e.range.getRow(), count: e.range.getNumRows(), silent: true });
+  } catch (err) {
+    Logger.log('onEdit error: ' + err);
+  }
+}
+
+function richTextToMarkdown(rich) {
+  if (!rich) return '';
+  const txt = rich.getText();
+  const runs = rich.getRuns();
+  let out = '', idx = 0;
+  runs.forEach(run => {
+    const start = run.getStartIndex();
+    const end = run.getEndIndex();
+    if (start > idx) out += txt.substring(idx, start);
+    let seg = txt.substring(start, end);
+    const style = run.getTextStyle();
+    if (style.isBold() && style.isItalic()) seg = `***${seg}***`;
+    else if (style.isBold()) seg = `**${seg}**`;
+    else if (style.isItalic()) seg = `*${seg}*`;
+    const link = run.getLinkUrl();
+    if (link) seg = `[${seg}](${link})`;
+    out += seg;
+    idx = end;
+  });
+  if (idx < txt.length) out += txt.substring(idx);
+  return out;
+}
+
+function syncExport(opts) {
+  const row = opts && opts.row;
+  const count = opts && opts.count;
+  const { src, exp } = ensureSheets();
+
+  if (row) {
+    const height = count || 1;
+    const rich = src.getRange(row, 1, height, 2).getRichTextValues();
+    const values = rich.map(r => [richTextToMarkdown(r[0]), richTextToMarkdown(r[1])]);
+    exp.getRange(row + 1, 1, height, 2).setValues(values);
+    exp.getRange('D1').setValue('Last sync: ' + new Date().toLocaleString());
+    SpreadsheetApp.flush();
+    if (!(opts && opts.silent)) toast(`Synced ${height} row(s) Source → Export`);
+    return;
+  }
+
+  const richRows = src.getRange(1, 1, src.getLastRow(), 2).getRichTextValues();
+  if (!richRows.length) {
+    if (!(opts && opts.silent)) toast('No data in "Source".');
+    return;
+  }
+  const data = richRows.map(r => [richTextToMarkdown(r[0]), richTextToMarkdown(r[1])]);
+
+  exp.clearContents();
+  exp.getRange(1, 1, 1, 2).setValues([HEADER]);
+  if (data.length) exp.getRange(2, 1, data.length, 2).setValues(data);
+  exp.getRange('D1').setValue('Last sync: ' + new Date().toLocaleString());
+  SpreadsheetApp.flush();
+  if (!(opts && opts.silent)) toast(`Synced ${data.length} row(s) Source → Export`);
+}
+
+function ensureSheets() {
+  const ss = SpreadsheetApp.getActive();
+  if (!ss) throw new Error('Open the spreadsheet, then Extensions → Apps Script.');
+  const src = ss.getSheetByName(SOURCE_SHEET);
+  if (!src) throw new Error(`Missing sheet named "${SOURCE_SHEET}". Rename your source tab exactly to "${SOURCE_SHEET}".`);
+  let exp = ss.getSheetByName(EXPORT_SHEET);
+  if (!exp) exp = ss.insertSheet(EXPORT_SHEET);
+  return { ss, src, exp };
+}
+function toast(msg) { SpreadsheetApp.getActive().toast(msg, 'Timeline Export', 3); }

--- a/apps-script/export.gs
+++ b/apps-script/export.gs
@@ -15,7 +15,7 @@ function onEdit(e) {
     if (!e || !e.range) return;
     const sh = e.range.getSheet();
     if (!sh || sh.getName() !== SOURCE_SHEET) return;
-    if (e.range.getColumn() > 2) return;
+    if (e.range.getColumn() > 2 || e.range.getLastColumn() > 2) return;
     Utilities.sleep(150);
     syncExport({ row: e.range.getRow(), count: e.range.getNumRows(), silent: true });
   } catch (err) {

--- a/scripts/markdown.js
+++ b/scripts/markdown.js
@@ -1,0 +1,58 @@
+// Markdown rendering helpers shared between browser and tests
+function escapeHTML(s){
+  return (s||"").replace(/[&<>"']/g, ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+}
+
+function renderMarkdown(text){
+  if(!text) return "";
+
+  // Replace explicit Markdown links with tokens so embedded HTML survives
+  const linkTokens=[]; let linkIdx=0;
+  let tmp = text.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,(m,label,url)=>{
+    const token=`__MDLINK_${linkIdx++}__`;
+    linkTokens.push({token, html:`<a href="${url}" target="_blank" rel="noopener noreferrer">${escapeHTML(label)}</a>`});
+    return token;
+  });
+
+  // Auto-link bare URLs and process basic Markdown for bold/italic.
+  tmp = tmp
+    .replace(/(https?:\/\/[^\s<)]+)([)\s.,;!?]*)/g,(m,url,trail)=>`<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>${trail}`)
+    .replace(/(^|[\s(])((?:www\.)[^\s<)]+)([)\s.,;!?]*)/g,(m,pre,url,trail)=>`${pre}<a href="https://${url}" target="_blank" rel="noopener noreferrer">${url}</a>${trail}`)
+    .replace(/(\*\*\*)([\s\S]+?)\1/g, '<strong><em>$2</em></strong>')
+    .replace(/(\*\*)([\s\S]+?)\1/g, '<strong>$2</strong>')
+    .replace(/(\*)([\s\S]+?)\1/g, '<em>$2</em>');
+
+  // Group blockquotes; recognise lines starting with '>'
+  {
+    const lines = tmp.split('\n'); const out = []; let buf = [];
+    const flush = () => { if (buf.length) { out.push('<blockquote>'+buf.join('<br>')+'</blockquote>'); buf=[]; } };
+    for (const raw of lines) {
+      const t = raw.trimStart();
+      if (t.startsWith('>')) buf.push(t.replace(/^>\s?/, '')); else { flush(); out.push(raw); }
+    }
+    flush(); tmp = out.join('\n');
+  }
+
+  tmp = tmp.replace(/\n/g,'<br>');
+  for(const L of linkTokens) tmp = tmp.replaceAll(L.token, L.html);
+  return tmp;
+}
+
+function stripHtml(html){
+  if (typeof document !== 'undefined'){
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    return (div.textContent || "").trim();
+  }
+  // Fallback for non-DOM environments (tests)
+  return (html || '').replace(/<[^>]*>/g,'').trim();
+}
+
+if (typeof window !== 'undefined'){
+  window.renderMarkdown = renderMarkdown;
+  window.stripHtml = stripHtml;
+}
+
+if (typeof module !== 'undefined' && module.exports){
+  module.exports = { renderMarkdown, stripHtml };
+}

--- a/tests/renderMarkdown.test.js
+++ b/tests/renderMarkdown.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { renderMarkdown } = require('../scripts/markdown.js');
+
+test('renders bold, italic and links', () => {
+  const input = 'This is **bold**, *italic*, and a [link](https://example.com).';
+  const html = renderMarkdown(input);
+  assert.match(html, /<strong>bold<\/strong>/);
+  assert.match(html, /<em>italic<\/em>/);
+  assert.match(html, /<a href="https:\/\/example.com" target="_blank" rel="noopener noreferrer">link<\/a>/);
+});

--- a/timeline.html
+++ b/timeline.html
@@ -74,6 +74,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
 <script src="scripts/parseCSV.js"></script>
+<script src="scripts/markdown.js"></script>
 <script src="scripts/timeline.js"></script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- sync only edited Source row by passing row number into `syncExport`
- rewrite `syncExport` to optionally update a single row and keep original row order
- handle multi-row edits by sending edited row count to `syncExport`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0058b1a08321a8acc1b01da659c8