### PR TITLE
Rebuild first section on edits

### DIFF
--- a/apps-script/export.gs
+++ b/apps-script/export.gs
@@ -53,6 +53,12 @@ function syncExport(opts) {
   // Single-row update (onEdit)
   if (row) {
     if (row === 1) return; // skip header row
+    const norm = s => (s || '').trim().toLowerCase();
+    const key = norm(src.getRange(row, 1, 1, 1).getRichTextValues()[0][0].getText());
+    const firstSectionKeys = ['section heading', 'section image', 'section caption', 'section description'];
+    if (firstSectionKeys.includes(key)) {
+      return syncExport({ silent: opts && opts.silent });
+    }
     const rich = src.getRange(row, 1, 1, 2).getRichTextValues()[0];
     const values = [richTextToMarkdown(rich[0]), richTextToMarkdown(rich[1])];
     exp.getRange(row, 1, 1, 2).setValues([values]);

--- a/tests/exportSync.test.js
+++ b/tests/exportSync.test.js
@@ -153,3 +153,25 @@ test('syncExport inserts missing Section Image and drops duplicate descriptions'
   ]);
 });
 
+test('editing first-section row rebuilds section and inserts missing image', () => {
+  const sourceData = [
+    [makeRichText('Type'), makeRichText('Value')],
+    [makeRichText('Section Heading'), makeRichText('Head')],
+    [makeRichText('Section Description'), makeRichText('One')],
+    [makeRichText('Section Caption'), makeRichText('cap')],
+    [makeRichText('Section Description'), makeRichText('Two', { bold: true })],
+  ];
+  const { sandbox, src, exp } = createEnv(sourceData);
+  sandbox.syncExport({ silent: true });
+  // Edit first Section Description row; export should still be normalized
+  src.data[2] = [makeRichText('Section Description'), makeRichText('Edited')];
+  sandbox.syncExport({ silent: true, row: 3 });
+  assert.deepStrictEqual(exp.data, [
+    ['Type', 'Value'],
+    ['Section Heading', 'Head'],
+    ['Section Image', ''],
+    ['Section Caption', 'cap'],
+    ['Section Description', '**Two**'],
+  ]);
+});
+


### PR DESCRIPTION
## Summary
- Rebuild entire export when editing Section Heading/Image/Caption/Description to maintain normalization
- Add regression test for editing first-section rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae51cfe18483218cd9004692cfb26a