### PR TITLE
Handle images and fallback display values in export

### DIFF
--- a/apps-script/export.gs
+++ b/apps-script/export.gs
@@ -50,12 +50,14 @@ function richTextToMarkdown(rich) {
 
 function resolveValue(typeRich, valueRich, row, src) {
   const key = norm(typeRich.getText());
-  if (key === 'section image') {
+  if (key.endsWith('image')) {
     // Preserve visible URL or =IMAGE() result
     const d = src.getRange(row, 2).getDisplayValue();
     return d !== '' ? d : valueRich.getText();
   }
-  return richTextToMarkdown(valueRich);
+  const md = valueRich ? richTextToMarkdown(valueRich) : '';
+  if (md) return md;
+  return src.getRange(row, 2).getDisplayValue();
 }
 
 function syncExport(opts) {


### PR DESCRIPTION
## Summary
- Expand `resolveValue` to treat any key ending with `image` as an image field, preserving its display value
- For non-image fields, convert rich text to markdown and fall back to the cell's displayed value when markdown is empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae78cdc2448321b321783932109001